### PR TITLE
fix(searxng): Fix document separator placement in configmap template

### DIFF
--- a/charts/searxng/Chart.yaml
+++ b/charts/searxng/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://kubito.dev
 apiVersion: v2
 appVersion: 1.0.1
-version: 1.0.1
+version: 1.0.2
 description: Kubito SearXNG Helm Chart
 home: https://github.com/kubitodev/helm/tree/main/charts/searxng
 icon: https://kubito.dev/images/kubito.svg

--- a/charts/searxng/templates/006-configmap.yaml
+++ b/charts/searxng/templates/006-configmap.yaml
@@ -14,7 +14,6 @@ data:
     {{- .Values.config.settings.data | nindent 4 }}
 {{- end }}
 
-
 {{- if .Values.config.limiter.enabled -}}
 ---
 apiVersion: v1

--- a/charts/searxng/templates/006-configmap.yaml
+++ b/charts/searxng/templates/006-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.config.settings.enabled -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,8 +14,9 @@ data:
     {{- .Values.config.settings.data | nindent 4 }}
 {{- end }}
 
----
+
 {{- if .Values.config.limiter.enabled -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,8 +31,8 @@ data:
     {{- .Values.config.limiter.data | nindent 4 }}
 {{- end }}
 
----
 {{- if .Values.config.uwsgi.enabled -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
# Kubito Helm Charts PR Checklist

Thank you for your contribution! Please ensure the following:

- [x] **Chart Version**: Updated `version` in `Chart.yaml` for the relevant chart.
- [ ] N/A ~**README Update**: If `values.yaml` was changed, run:~

  ```bash
  readme-generator -v charts/your-chart/values.yaml -r charts/your-chart/README.md
  ```

- [x] **Testing**: Tested the chart locally, and it works as expected.

## Testing
### Steps to reproduce

1. Render the chart with the following Helm values:
```yaml
# An API-compatible example for as of chart 1.0.1
config:
  settings:
    enabled: true
  limiter:
    enabled: false
  uwsgi:
    enabled: true
```
2. Render the chart, and inspect the immediate vicinity of the `searxng-uwsgi` ConfigMap. 
```bash
helm template searxng kubitodev/searxng --version 1.0.1 --values values.yaml 

# trimmed
        - html
        - json
---
# Source: searxng/templates/006-configmap.yaml
---apiVersion: v1
kind: ConfigMap
metadata:
  name: searxng-uwsgi
# trimmed
```

### Expected result
YAML document separators for the chart's configmap template are rendered properly regardless of the configuration enablement (`.Values.config.<key>.enabled`).

### Actual result
Given the above test vector, the YAML document separator is placed on the same line as the K8s `apiVersion` definition.
This causes issues downstream, since the spec is now broken. For example, this was initially observed via a failed reconciliation by the Flux Helm controller:
```
Helm upgrade failed for release searxng/searxng with chart searxng@1.0.1: error while running post render on files: invalid document separator: ---apiVersion: v1
```

### Other test vectors used for validation

All configs disabled
```yaml
config:
  settings:
    enabled: false
  limiter:
    enabled: false
  uwsgi:
    enabled: false
```

```bash
 helm template searxng kubitodev/searxng --version 1.0.1  --values values.yaml  | grep -C 2 ' searxng/templates/006-configmap.yaml'
      volumes:
---
# Source: searxng/templates/006-configmap.yaml
---
```

---

All configs enabled
```yaml
config:
  settings:
    enabled: true
  limiter:
    enabled: true
  uwsgi:
    enabled: true
```

```bash
helm template searxng kubitodev/searxng --version 1.0.1  --values values.yaml  | grep -C 2 ' searxng/templates/006-configmap.yaml'
automountServiceAccountToken: true
---
# Source: searxng/templates/006-configmap.yaml
apiVersion: v1
kind: ConfigMap
--
        - json
---
# Source: searxng/templates/006-configmap.yaml
apiVersion: v1
kind: ConfigMap
--
    link_token = true
---
# Source: searxng/templates/006-configmap.yaml
apiVersion: v1
kind: ConfigMap
```

## Changes Summary

Moves the YAML document separators inside of the `if` scopes. This ensures they're not duplicated and present only when actually necessary.

## Related Issues

N/A
