### PR TITLE
fix(cloudflared): enable metrics correctly 

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://kubito.dev
 apiVersion: v2
 appVersion: 2025.2.1
-version: 1.6.1
+version: 1.6.2
 description: Kubito Cloudflared (Argo Tunnel) Helm Chart
 home: https://github.com/kubitodev/helm/tree/main/charts/cloudflared
 icon: https://kubito.dev/images/kubito.svg

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       - args:
         - tunnel
         - --no-autoupdate
+        {{- if .Values.metrics.enabled }}
+        - --metrics
+        - "0.0.0.0:{{ .Values.metrics.port }}"
+        {{ end }}
         {{- if .Values.local.enabled }}
         - --config
         - /etc/cloudflared/config.yaml
@@ -33,10 +37,6 @@ spec:
         - --loglevel
         - {{ .Values.logLevel }}
         {{- end }}
-        {{- if .Values.metrics.enabled }}
-        - --metrics
-        - "0.0.0.0:{{ .Values.metrics.port }}"
-        {{ end }}
         - run
         - --token
         - $(CF_MANAGED_TUNNEL_TOKEN)


### PR DESCRIPTION
# Kubito Helm Charts PR Checklist

Thank you for your contribution! Please ensure the following:

- [x] **Chart Version**: Updated `version` in `Chart.yaml` for the relevant chart.
- [] **README Update**: If `values.yaml` was changed, run:

  ```bash
  readme-generator -v charts/your-chart/values.yaml -r charts/your-chart/README.md
  ```

- [x] **Testing**: Tested the chart locally, and it works as expected.

## Changes Summary

The `metrics.enabled` toggle does not work as expected; it does not enable metrics if the `managed` deployment is not toggled on.  I want metrics on even for the `local` deployment.
Ref: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/monitor-tunnels/metrics/

## Related Issues
