### PR TITLE
feat(cloudflared): configure deployment replicaCount only if hpa is not enabled 

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://kubito.dev
 apiVersion: v2
 appVersion: 2025.5.0
-version: 1.7.0
+version: 1.7.1
 description: Kubito Cloudflared (Argo Tunnel) Helm Chart
 home: https://github.com/kubitodev/helm/tree/main/charts/cloudflared
 icon: https://kubito.dev/images/kubito.svg

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -7,7 +7,9 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount | int }}
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
# Kubito Helm Charts PR Checklist

Thank you for your contribution! Please ensure the following:

- [x] **Chart Version**: Updated `version` in `Chart.yaml` for the relevant chart.
- [] **README Update**: If `values.yaml` was changed, run:

  ```bash
  readme-generator -v charts/your-chart/values.yaml -r charts/your-chart/README.md
  ```

- [x] **Testing**: Tested the chart locally, and it works as expected.

## Changes Summary
When an HPA is enabled, it is recommended that the value of `spec.replicas` of the Deployment be removed from its manifest, see [official documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling)
This PR adds a check for when autoscaling is enabled, if not enabled, use the `replicaCount` value from the values file, else remove configuration.

## Related Issues
