### PR TITLE
Fixing the broken ingress template after v1.1.0 changed the service name

### DIFF
--- a/charts/searxng/Chart.yaml
+++ b/charts/searxng/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://kubito.dev
 apiVersion: v2
 appVersion: 1.0.1
-version: 1.1.0
+version: 1.1.1
 description: Kubito SearXNG Helm Chart
 home: https://github.com/kubitodev/helm/tree/main/charts/searxng
 icon: https://kubito.dev/images/kubito.svg

--- a/charts/searxng/templates/003-ingress.yaml
+++ b/charts/searxng/templates/003-ingress.yaml
@@ -52,11 +52,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: searxng
+                name: searxng-http
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: searxng
+              serviceName: searxng-http
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
## Changes Summary

Fixing the broken ingress template after v1.1.0 changed the service name

## Related Issues

