### PR TITLE
Update searxng ingress to match service name

### DIFF
--- a/charts/searxng/Chart.yaml
+++ b/charts/searxng/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://kubito.dev
 apiVersion: v2
 appVersion: 1.0.1
-version: 1.1.0
+version: 1.1.1
 description: Kubito SearXNG Helm Chart
 home: https://github.com/kubitodev/helm/tree/main/charts/searxng
 icon: https://kubito.dev/images/kubito.svg

--- a/charts/searxng/templates/003-ingress.yaml
+++ b/charts/searxng/templates/003-ingress.yaml
@@ -52,11 +52,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: searxng
+                name: searxng-http
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: searxng
+              serviceName: searxng-http
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
# Kubito Helm Charts PR Checklist

Thank you for your contribution! Please ensure the following:

- [x] **Chart Version**: Updated `version` in `Chart.yaml` for the relevant chart.
- [x] **README Update**: If `values.yaml` was changed, run:

  ```bash
  readme-generator -v charts/your-chart/values.yaml -r charts/your-chart/README.md
  ```

- [x] **Testing**: Tested the chart locally, and it works as expected.

## Changes Summary

Recent fix https://github.com/kubitodev/helm/commit/0172eecf7762e4013829031ead373fba4f1c4783 updated the service name, but not the matching serviceName as part of the ingress manifest.
